### PR TITLE
Added ToJSON and FromJSON instances

### DIFF
--- a/Yesod/Text/Markdown.hs
+++ b/Yesod/Text/Markdown.hs
@@ -15,6 +15,9 @@ import Data.Text (Text)
 import Data.Text.Lazy (toStrict, fromStrict)
 import Text.Markdown (Markdown (Markdown))
 import Database.Persist.Sql
+import Control.Applicative ((<$>))
+import Control.Monad (mzero)
+import Data.Aeson
 
 instance PersistField Markdown where
   toPersistValue (Markdown t) = PersistText $ toStrict t
@@ -23,6 +26,13 @@ instance PersistField Markdown where
 
 instance PersistFieldSql Markdown where
     sqlType _ = SqlString
+
+instance ToJSON Markdown where
+  toJSON (Markdown text) = object ["markdown" .= text]
+
+instance FromJSON Markdown where
+  parseJSON (Object v) = Markdown <$> v .: "markdown"
+  parseJSON _ = mzero
 
 markdownField :: (Monad m, RenderMessage (HandlerSite m) FormMessage) => Field m Markdown
 markdownField = Field

--- a/yesod-text-markdown.cabal
+++ b/yesod-text-markdown.cabal
@@ -1,5 +1,5 @@
 name:                yesod-text-markdown
-version:             0.1.4
+version:             0.1.5
 synopsis:            Yesod support for Text.Markdown.
 description:         Use Text.Markdown in a typical yesod project.
                      This module contains instances related to persistence,
@@ -41,6 +41,7 @@ library
                    , persistent           >= 1.2  && < 2.0
                    , text                 >= 0.11 && < 2.0
                    , shakespeare          >= 2.0  && < 2.1
+                   , aeson                >= 0.7  && < 0.9
   ghc-options: -Wall -fno-warn-orphans
 
 source-repository head


### PR DESCRIPTION
Hi,

This adds ToJSON and FromJSON instances to the Markdown newtype, so that it can be used in persistent entities with the JSON flag:

https://github.com/yesodweb/persistent/wiki/Persistent-entity-syntax#json-instances

As Aeson is already one of the dependencies on Yesod, I don't believe this as any major impact.

What do you think?
Cheers,
João
