### PR TITLE
Document markdownField

### DIFF
--- a/Yesod/Text/Markdown.hs
+++ b/Yesod/Text/Markdown.hs
@@ -34,6 +34,7 @@ instance FromJSON Markdown where
   parseJSON (Object v) = Markdown <$> v .: "markdown"
   parseJSON _ = mzero
 
+-- | Creates a @\<textarea>@ tag whose returned value is wrapped in a 'Markdown' newtype; see 'Markdown' for details.
 markdownField :: (Monad m, RenderMessage (HandlerSite m) FormMessage) => Field m Markdown
 markdownField = Field
     { fieldParse = parseHelper $ Right . Markdown . fromStrict


### PR DESCRIPTION
Documents `markdownField` in the same style that [`textareaField` is documented](https://github.com/yesodweb/yesod/blob/9d748b2c358d64ad823722c9e8bc6332c47e8466/yesod-form/Yesod/Form/Fields.hs#L230).
